### PR TITLE
ocrnet bugs

### DIFF
--- a/official/cv/OCRNet/src/modules/ocrnet.py
+++ b/official/cv/OCRNet/src/modules/ocrnet.py
@@ -1,4 +1,5 @@
 import math
+import mindspore  as ms
 from mindspore.common.initializer import HeUniform
 from mindspore import ops, nn
 from .backbone import create_backbone
@@ -25,7 +26,7 @@ class SpatialGatherModule(nn.Cell):
         # [batch_size, height*width, num_classes]
         feats = feats.transpose((0, 2, 1))
         # [batch_size, channels, height*width]
-        probs = ops.softmax(self.scale * probs, axis=2)
+        probs = ops.softmax(self.scale * probs.to(ms.float32), axis=2).to(probs.dtype)
         # [batch_size, channels, num_classes]
         ocr_context = ops.matmul(probs, feats)
         ocr_context = ocr_context.transpose((0, 2, 1)).unsqueeze(3)
@@ -160,7 +161,7 @@ class SelfAttentionBlock(nn.Cell):
         sim_map = ops.matmul(query, key)
         if self.matmul_norm:
             sim_map = (self.channels**-0.5) * sim_map
-        sim_map = ops.softmax(sim_map, axis=-1)
+        sim_map = ops.softmax(sim_map.to(ms.float32), axis=-1).to(sim_map.dtype)
 
         context = ops.matmul(sim_map, value)
         context = context.transpose((0, 2, 1))

--- a/official/cv/OCRNet/train.py
+++ b/official/cv/OCRNet/train.py
@@ -136,6 +136,10 @@ if __name__ == "__main__":
     # Network
     network = OCRNet(config)
     ms.amp.auto_mixed_precision(network, config.amp_level)
+    # 单卡O3不溢出，多卡O3溢出，大概率是BN输出精度不够，影响后面算子
+    for _, cell in network.cells_and_names():
+        if isinstance(cell, (nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d, nn.SyncBatchNorm)):
+            cell.to_float(ms.float32)
 
     if config.run_eval:
         from src.modules.base_modules import MultiScaleInfer


### PR DESCRIPTION
ocrnet 各种bug及修改记录留存

关闭融合A_MomentumLossscaleFusionPass，修改bn和softmax精度为float32

8卡边训边推
![image](https://github.com/mindspore-lab/models/assets/28288770/68b4892d-e01e-430e-ab09-e403c2ca3335)

单卡推理best ckpt，带multiscale
![image](https://github.com/mindspore-lab/models/assets/28288770/3ac8f213-32a1-415e-9cf7-04c5ed0bd58c)

性能fps = 8cards * bs2 / 189.5ms = 84.43。官网标注8卡 85.10
精度 = 82.15%。官网标注8卡 82.27%

2022/12/8 update 云上训练
![image](https://github.com/mindspore-lab/models/assets/28288770/3ebb0fdb-b30a-4ed5-824c-85d6f480af38)

