### PR TITLE
Solve the preprocessing bug of the pgnet model during inference

### DIFF
--- a/research/huawei-ostd/PGNet/tools/infer/predict_e2e.py
+++ b/research/huawei-ostd/PGNet/tools/infer/predict_e2e.py
@@ -50,10 +50,10 @@ class TextEnd2End(object):
 
         # build preprocess and postprocess
         self.preprocess = Preprocessor(
-            task="det",
+            task="e2e",
             algo=args.e2e_algorithm,
-            det_limit_side_len=args.e2e_limit_side_len,
-            det_limit_type=args.e2e_limit_type,
+            e2e_limit_side_len=args.e2e_limit_side_len,
+            e2e_limit_type=args.e2e_limit_type,
         )
 
         self.postprocess = Postprocessor(task="e2e", algo=args.e2e_algorithm)

--- a/research/huawei-ostd/PGNet/tools/infer/preprocess.py
+++ b/research/huawei-ostd/PGNet/tools/infer/preprocess.py
@@ -40,7 +40,22 @@ class Preprocessor(object):
                 {"ToCHWImage": None},
             ]
             _logger.info(f"Pick optimal preprocess hyper-params for det algo {algo}:\n {pipeline[1]}")
-
+        elif task == "e2e":
+            limit_side_len = kwargs.get("e2e_limit_side_len", 768)
+            limit_type = kwargs.get("e2e_limit_type", "max")
+            pipeline = [
+                {"DecodeImage": {"img_mode": "BGR", "to_float32": False}},
+                {"E2EResizeForTest": {"max_side_len": limit_side_len, "dataset": "totaltext"}},
+                {
+                    "NormalizeImage": {
+                        "bgr_to_rgb": False,
+                        "is_hwc": True,
+                        "mean": IMAGENET_DEFAULT_MEAN,
+                        "std": IMAGENET_DEFAULT_STD,
+                    }
+                },
+                {"ToCHWImage": None},
+            ]
         self.pipeline = pipeline
         self.transforms = create_transforms(pipeline)
 


### PR DESCRIPTION
最近，使用PGNet模型进行图片推理时出现以下bug：
![微信图片_20250106201618](https://github.com/user-attachments/assets/072cfa27-131b-415b-80ec-36267d755fb9)
经分析，图片推理前的预处理代码有问题，已解决：
![微信图片_20250106201624](https://github.com/user-attachments/assets/f8869832-e5d2-4fb6-9b62-4bb296e2b0d7)
图片推理效果如下：
![e2e_res_img12](https://github.com/user-attachments/assets/2b827724-b42b-4db2-9bc0-be71a220a2b1)


